### PR TITLE
Make the Engine Web worker compatible

### DIFF
--- a/dvipdfm.wasm/DvipdfmxEngine.js
+++ b/dvipdfm.wasm/DvipdfmxEngine.js
@@ -1,5 +1,3 @@
-"use strict";
-var exports = {};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -36,8 +34,6 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
         if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
     }
 };
-exports.__esModule = true;
-exports.DvipdfmxEngine = exports.CompileResult = exports.EngineStatus = void 0;
 /********************************************************************************
  * Copyright (C) 2019 Elliott Wen.
  *
@@ -53,14 +49,14 @@ exports.DvipdfmxEngine = exports.CompileResult = exports.EngineStatus = void 0;
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-var EngineStatus;
+export var EngineStatus;
 (function (EngineStatus) {
     EngineStatus[EngineStatus["Init"] = 1] = "Init";
     EngineStatus[EngineStatus["Ready"] = 2] = "Ready";
     EngineStatus[EngineStatus["Busy"] = 3] = "Busy";
     EngineStatus[EngineStatus["Error"] = 4] = "Error";
-})(EngineStatus = exports.EngineStatus || (exports.EngineStatus = {}));
-var XDVPDFMX_ENGINE_PATH = 'swiftlatexdvipdfm.js';
+})(EngineStatus || (EngineStatus = {}));
+var XDVPDFMX_ENGINE_PATH = new URL('./swiftlatexdvipdfm.js', import.meta.url).toString();
 var CompileResult = /** @class */ (function () {
     function CompileResult() {
         this.pdf = undefined;
@@ -69,7 +65,7 @@ var CompileResult = /** @class */ (function () {
     }
     return CompileResult;
 }());
-exports.CompileResult = CompileResult;
+export { CompileResult };
 var DvipdfmxEngine = /** @class */ (function () {
     function DvipdfmxEngine() {
         this.latexWorker = undefined;
@@ -198,4 +194,4 @@ var DvipdfmxEngine = /** @class */ (function () {
     };
     return DvipdfmxEngine;
 }());
-exports.DvipdfmxEngine = DvipdfmxEngine;
+export { DvipdfmxEngine };

--- a/dvipdfm.wasm/DvipdfmxEngine.tsx
+++ b/dvipdfm.wasm/DvipdfmxEngine.tsx
@@ -20,7 +20,7 @@ export enum EngineStatus {
     Error,
 }
 
-const XDVPDFMX_ENGINE_PATH = 'swiftlatexdvipdfm.js';
+const XDVPDFMX_ENGINE_PATH = new URL('./swiftlatexdvipdfm.js', import.meta.url).toString();
 
 export class CompileResult {
     pdf: Uint8Array | undefined = undefined;
@@ -38,7 +38,7 @@ export class DvipdfmxEngine {
             throw new Error('Other instance is running, abort()');
         }
         this.latexWorkerStatus = EngineStatus.Init;
-        await new Promise((resolve, reject) => {
+        await new Promise<void>((resolve, reject) => {
             this.latexWorker = new Worker(XDVPDFMX_ENGINE_PATH);
             this.latexWorker.onmessage = (ev: any) => {
                 const data: any = ev.data;

--- a/dvipdfm.wasm/Makefile
+++ b/dvipdfm.wasm/Makefile
@@ -3,6 +3,7 @@ CXX=em++
 DEBUGFLAGS = -O3
 CFLAGS = $(DEBUGFLAGS) -DHAVE_ZLIB -s USE_LIBPNG=1 -fno-rtti -fno-exceptions
 LDFLAGS =  $(DEBUGFLAGS)  --js-library library.js  \
+	-s ENVIRONMENT="web" \
   -s USE_LIBPNG=1 --pre-js pre.js \
  -s EXPORTED_FUNCTIONS='["_compilePDF", "_setMainEntry", "_main"]' -s NO_EXIT_RUNTIME=1 \
   -s WASM=1 -s ALLOW_MEMORY_GROWTH=1 -fno-rtti -fno-exceptions

--- a/dvipdfm.wasm/tsconfig.json
+++ b/dvipdfm.wasm/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+      "lib": ["dom", "es2020"],
+      "module": "es2020"
+  }
+}

--- a/xetex.wasm/Makefile
+++ b/xetex.wasm/Makefile
@@ -6,6 +6,7 @@ CFLAGS = $(DEBUGFLAGS) -Wno-parentheses-equality -Wno-pointer-sign -DWEBASSEMBLY
  -s USE_FREETYPE=1 -s USE_ICU=1 -s USE_LIBPNG=1 -fno-rtti -fno-exceptions
 
 LDFLAGS =  $(DEBUGFLAGS) --js-library library.js \
+ -s ENVIRONMENT="web" \
  -s USE_FREETYPE=1 \
  -s USE_ICU=1 \
  -s USE_LIBPNG=1 \

--- a/xetex.wasm/XeTeXEngine.js
+++ b/xetex.wasm/XeTeXEngine.js
@@ -1,4 +1,3 @@
-"use strict";
 /********************************************************************************
  * Copyright (C) 2019 Elliott Wen.
  *
@@ -14,7 +13,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-var exports = {};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -51,16 +49,14 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
         if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
     }
 };
-exports.__esModule = true;
-exports.XeTeXEngine = exports.CompileResult = exports.EngineStatus = void 0;
-var EngineStatus;
+export var EngineStatus;
 (function (EngineStatus) {
     EngineStatus[EngineStatus["Init"] = 1] = "Init";
     EngineStatus[EngineStatus["Ready"] = 2] = "Ready";
     EngineStatus[EngineStatus["Busy"] = 3] = "Busy";
     EngineStatus[EngineStatus["Error"] = 4] = "Error";
-})(EngineStatus = exports.EngineStatus || (exports.EngineStatus = {}));
-var ENGINE_PATH = 'swiftlatexxetex.js';
+})(EngineStatus || (EngineStatus = {}));
+var ENGINE_PATH = new URL('./swiftlatexxetex.js', import.meta.url).toString();
 var CompileResult = /** @class */ (function () {
     function CompileResult() {
         this.pdf = undefined;
@@ -69,7 +65,7 @@ var CompileResult = /** @class */ (function () {
     }
     return CompileResult;
 }());
-exports.CompileResult = CompileResult;
+export { CompileResult };
 var XeTeXEngine = /** @class */ (function () {
     function XeTeXEngine() {
         this.latexWorker = undefined;
@@ -244,4 +240,4 @@ var XeTeXEngine = /** @class */ (function () {
     };
     return XeTeXEngine;
 }());
-exports.XeTeXEngine = XeTeXEngine;
+export { XeTeXEngine };

--- a/xetex.wasm/XeTeXEngine.tsx
+++ b/xetex.wasm/XeTeXEngine.tsx
@@ -22,7 +22,7 @@ export enum EngineStatus {
 	Error
 }
 
-const ENGINE_PATH = 'swiftlatexxetex.js';
+const ENGINE_PATH = new URL('./swiftlatexxetex.js', import.meta.url).toString();
 
 export class CompileResult {
 	pdf: Uint8Array | undefined = undefined;
@@ -42,7 +42,7 @@ export class XeTeXEngine {
 			throw new Error('Other instance is running, abort()');
 		}
 		this.latexWorkerStatus = EngineStatus.Init;
-		await new Promise((resolve, reject) => {
+		await new Promise<void>((resolve, reject) => {
 			this.latexWorker = new Worker(ENGINE_PATH);
 			this.latexWorker.onmessage = (ev: any) => {
 				const data: any = ev['data'];
@@ -108,7 +108,7 @@ export class XeTeXEngine {
 	public async compileFormat(): Promise<void> {
 		this.checkEngineStatus();
 		this.latexWorkerStatus = EngineStatus.Busy;
-		await new Promise((resolve, reject) => {
+		await new Promise<void>((resolve, reject) => {
 			this.latexWorker!.onmessage = (ev: any) => {
 				const data: any = ev['data'];
 				const cmd: string =  data['cmd'] as string;

--- a/xetex.wasm/tsconfig.json
+++ b/xetex.wasm/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+      "lib": ["dom", "es2020"],
+      "module": "es2020"
+  }
+}


### PR DESCRIPTION
During the compilation to WASM, I noticed that the resulting JavaScript is not compatible with webpack and also includes Node.js code, which is usually ignored if loaded through HTML. The small changes made here, allow one to import the SwiftLaTeX engine using import statements and thus make it compatible with webpack.